### PR TITLE
change smartPtrWritingPerf to smartPtrReadingPerf

### DIFF
--- a/perf_cases/ddr_bandwidth/ddrPerf.hpp
+++ b/perf_cases/ddr_bandwidth/ddrPerf.hpp
@@ -117,7 +117,7 @@ private:
 
         {
             auto begin = m_profiler->getCurrentTimePoint();
-            smartPtrWritingPerf(m_test_arr, m_rw_cnt);
+            smartPtrReadingPerf(m_test_arr, m_rw_cnt);
             auto end = m_profiler->getCurrentTimePoint();
             auto smart_ptr_read_latency = m_profiler->getLatencyUs(begin, end);
             m_smart_read_bw_mb = getDDRBandwidthMB(smart_ptr_read_latency);


### PR DESCRIPTION
In the function "void onProcess() override", the fourth test function " smartPtrWritingPerf" seems need to be changed to "smartPtrReadingPerf"